### PR TITLE
DB9 Pinout for general analog (Aux)

### DIFF
--- a/docs/SMPL/smpl_standard.md
+++ b/docs/SMPL/smpl_standard.md
@@ -278,3 +278,27 @@ DB9 to any 4-pin SMPL device, expanding compatibility across your equipment.
     <td>Shield to Case GND</td>
   </tr>
 </table>
+
+### General Analog
+<table>
+  <tr bgcolor="gray">
+    <td><b>SMPL Pin</b></td>
+    <td><b>DB9 Pin</b></td>
+    <td><b>Description</b></td>
+  </tr>
+  <tr>
+    <td>A</td>
+    <td>8</td>
+    <td>-Input</td>
+  </tr>
+  <tr>
+    <td>B</td>
+    <td>7</td>
+    <td>+Input</td>
+  </tr>
+  <tr>
+    <td>S</td>
+    <td>3</td>
+    <td>Shield to Case GND</td>
+  </tr>
+


### PR DESCRIPTION
Added a standard pinout table for general DB9 analog inputs in a SMPL Ecosystem.

NOTE: A strange page navigation window appeared between my table added at the bottom of the page and the Loadcell table above it. It is not in the markdown code and should not be there in the render.
![Screenshot 2024-07-01 123834](https://github.com/LeemanGeophysicalLLC/knowledgebase/assets/69806819/47259270-9a05-451f-8b76-bdf788d640d8)
